### PR TITLE
Implemented BlankIsNone functionality

### DIFF
--- a/docs/config_prog.md
+++ b/docs/config_prog.md
@@ -47,8 +47,8 @@ if cfg.HasFailures():
 
 Access methods can be found on both the **uConfig** and **uConfigSection** classes.  _None_ is returned when a value is not found. **uConfig** methods access `*root` section values.  The `*root` section has values that come before any section headers are specified.
 
-- **HasValue(*Name*, *Raw*=False)**: Returns _True_ if the value was provided in configuration
-- **GetValue(*Name*,*Default*=None,*Raw*=False)**: Value as a string
+- **HasValue(*Name*, *Raw*=False, *BlankIsNone*=True)**: Returns _True_ if the value was provided in configuration
+- **GetValue(*Name*,*Default*=None,*Raw*=False, *BlankIsNone*=True)**: Value as a string
 - **GetBool(*Name*,*Default*=None)**: Returns _True_ when value is "true", case insensitive; otherwise _False_
 - **GetNumber(*Name*,*Default*=None)**: Returns value as an int.  Returns _False_ when value does not convert to int
 - **GetFloat(*Name*,*Default*=None)**: Returns value as a float.  Returns _False_ when value does not convert to float
@@ -56,8 +56,8 @@ Access methods can be found on both the **uConfig** and **uConfigSection** class
 
 **uConfig** also has quick methods for accessing section values directly.  If there are multiple sections with the same name, accesses the first one.
 
-- **HasSectionValue(*Section*,*Name*,*Default*=None,*Raw*=False)**
-- **GetSectionValue(*Section*,*Name*,*Default*=None,*Raw*=False)**
+- **HasSectionValue(*Section*,*Name*,*Default*=None,*Raw*=False, *BlankIsNone*=True)**
+- **GetSectionValue(*Section*,*Name*,*Default*=None,*Raw*=False, *BlankIsNone*=True)**
 - **GetSectionBool(*Section*,*Name*,*Default*=None)**
 - **GetSectionNumber(*Section*,*Name*,*Default*=None)**
 - **GetSectionFloat(*Section*,*Name*,*Default*=None)**
@@ -73,12 +73,35 @@ The priority order of a returned value is:
   3. A section value
   4. A `[*default]` section in the configuration file
 
-When a configuration property appears in configuration but is blank, **HasValue()** will return *True* and **GetValue()** will return an empty string.
+When a configuration property appears in configuration but is blank, **HasValue()** will return *False* and **GetValue()** will return None.
+
+This behavior can be changed by specifying **BlankIsNone** of *False*, in which case the empty string is returned.
+
 
 ```ini
-[MySection]
+[One]
+# property not specified
+
+[Two]
 # property specified but is blank
 MyProp=
+```
+
+```python
+# returns None
+config.GetSectionValue('One', 'MyProp')
+# returns None
+config.GetSectionValue('One', 'MyProp', BlankIsNone=False)
+
+# returns None
+config.GetSectionValue('Two', 'MyProp')
+# returns ""
+config.GetSectionValue('Two', 'MyProp', BlankIsNone=False)
+
+# returns "Egg"
+config.GetSectionValue('Two', 'MyProp', Default="Egg")
+# returns ""
+config.GetSectionValue('Two', 'MyProp', Default="Egg", BlankIsNone=False)
 ```
 
 ### Section access
@@ -110,8 +133,8 @@ Return a list of sections.
 - **IsMatch(*Name*=None,*Id*=None,*Label*=None)**: Returns *True* when section satisfies some combination of section name, id, or label
 
 The section also has the normal property access methods.
-- **HasValue(*Name*, *Raw*=False)**
-- **GetValue(*Name*)**
+- **HasValue(*Name*, *Raw*=False, *BlankIsNone*=True)**
+- **GetValue(*Name*, *BlankIsNone*=True)**
 - **GetBool(*Name*)**
 - **GetNumber(*Name*)**
 - **GetFloat(*Name*)**

--- a/m9ini/u_config.py
+++ b/m9ini/u_config.py
@@ -429,23 +429,27 @@ class uConfig:
         # returns a string value
         return self.GetSectionLink('*root', Name)
        
-    def HasValue(self, Name)->str:
+    def HasValue(self, Name, BlankIsNone=True)->str:
         '''
         Returns *True* if the specified value was defined in configuration.
         
         Equivalent to HasSectionValue('*root', Name).
+
+        If **BlankIsNone** is *True, an blank value in configuration returns *False*.  Otherwise, a *True* is returned.
         '''
         # returns a string value
-        return self.HasSectionValue('*root', Name)
+        return self.HasSectionValue('*root', Name, BlankIsNone=BlankIsNone)
     
-    def GetValue(self, Name, Default=None)->str:
+    def GetValue(self, Name, Default=None, BlankIsNone=True)->str:
         '''
         Returns a root value.  Equivalent to GetSectionValue('*root', Name).
 
         If *Name* is not found, *Default* is returned.
+
+        If **BlankIsNone** is *True*, a blank value specified in configuration is returned as *None*, and defaults apply.  Otherwise, an empty string is returned.
         '''
         # returns a string value
-        return self.GetSectionValue('*root', Name, Default)
+        return self.GetSectionValue('*root', Name, Default, BlankIsNone=BlankIsNone)
     
     def GetBool(self, Name, Default=None)->bool:
         '''
@@ -497,7 +501,7 @@ class uConfig:
 
         return None
     
-    def HasSectionValue(self, Section, Name, Raw=False)->str:
+    def HasSectionValue(self, Section, Name, Raw=False, BlankIsNone=True)->str:
         '''
         Returns *True* if the value was defined using a section specification by getting the first matching section.
 
@@ -508,13 +512,15 @@ class uConfig:
         Returns *False* if there is no matching section, or the section does not have the named value.
 
         If **Raw** is *True*, does not apply defaults, overrides, or parameters.
+
+        If **BlankIsNone** is *True, an blank value in configuration returns *False*.  Otherwise, a *True* is returned.
         '''
         section = self.GetSection(Section)
         if section is not None:
-            return section.HasValue(Name, Raw=Raw)
+            return section.HasValue(Name, Raw=Raw, BlankIsNone=BlankIsNone)
         return False
 
-    def GetSectionValue(self, Section, Name, Default=None, Raw=False)->str:
+    def GetSectionValue(self, Section, Name, Default=None, Raw=False, BlankIsNone=True)->str:
         '''
         Gets a value using a section specification by getting the first matching section.
 
@@ -525,10 +531,12 @@ class uConfig:
         Returns *Default* if there is no matching section, or the section does not have the named value.
 
         If **Raw** is *True*, does not apply defaults, overrides, or parameters.
+
+        If **BlankIsNone** is *True*, a blank value specified in configuration is returned as *None*, and defaults apply.  Otherwise, an empty string is returned.
         '''
         section = self.GetSection(Section)
         if section is not None:
-            return section.GetValue(Name, Default=Default, Raw=Raw)
+            return section.GetValue(Name, Default=Default, Raw=Raw, BlankIsNone=BlankIsNone)
         return Default
 
     def GetSectionBool(self, Section, Name, Default=None)->bool:

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -14,8 +14,12 @@ class TestConfig(_test_case.uTestCase):
 
     def test_config_structure(self):
         # by default, GetValue () accesses root level
-        self.assertEqual(self.config.GetValue('empty'), "")
+        self.assertEqual(self.config.GetValue('empty'), None)
+        self.assertEqual(self.config.GetValue('empty', Default='ping'), 'ping')
+        self.assertEqual(self.config.GetValue('empty', BlankIsNone=False), "")
+        self.assertEqual(self.config.GetValue('empty', Default='ping', BlankIsNone=False), "")
         self.assertEqual(self.config.GetValue('not-found'), None)
+        self.assertEqual(self.config.GetValue('not-found', Default='ping'), 'ping')
         self.assertEqual(self.config.GetValue('foo'), '9')
         # test that a number is converting properly
         self.assertEqual(self.config.GetNumber('foo'), 9)
@@ -73,14 +77,25 @@ class TestConfig(_test_case.uTestCase):
         config_ini = self.GetFilepath("test_blank.ini")
         config = uConfig(config_ini)
         section = config.GetSection("Blank")
-        self.assertEqual(section.HasValue("two"), True)
-        self.assertEqual(section.GetValue("two"), "")
+        self.assertEqual(section.HasValue("two"), False)
+        self.assertEqual(section.HasValue("two", BlankIsNone=False), True)
+        self.assertEqual(section.GetValue("two"), None)
+        self.assertEqual(section.GetValue("two", BlankIsNone=False), '')
+        self.assertEqual(section.HasValue("two"), False)
+        self.assertEqual(section.HasValue("two", BlankIsNone=False), True)
+        self.assertEqual(section.GetValue("two"), None)
+        self.assertEqual(section.GetValue("two", BlankIsNone=False), '')
         section = config.GetSection("Blank2")
-        self.assertEqual(section.HasValue("two"), True)
-        self.assertEqual(section.GetValue("two"), "")
-        self.assertEqual(section.HasValue("four"), True)
-        self.assertEqual(section.GetValue("four"), "")
+        self.assertEqual(section.HasValue("two"), False)
+        self.assertEqual(section.GetValue("two"), None)
+        self.assertEqual(section.HasValue("two", BlankIsNone=False), True)
+        self.assertEqual(section.GetValue("two", BlankIsNone=False), '')
+        self.assertEqual(section.HasValue("four"), False)
+        self.assertEqual(section.GetValue("four"), None)
+        self.assertEqual(section.HasValue("four", BlankIsNone=False), True)
+        self.assertEqual(section.GetValue("four", BlankIsNone=False), '')
         self.assertEqual(section.FormatString("x[=two]x"), "xx")
+        pass
 
     def test_config_include(self):
         self.assertEqual(self.config.GetSection('global_section').GetValue('global_value'),'lalala')

--- a/test/test_merge.py
+++ b/test/test_merge.py
@@ -22,7 +22,8 @@ class TestMerge(_test_case.uTestCase):
         self.assertEqual(section.GetName(), "Merged")
         self.assertEqual(config.GetSectionValue("Merged", "x"), "xxx")
         self.assertEqual(config.GetSectionValue("Merged", "y"), "two")
-        self.assertEqual(config.GetSectionValue("Merged", "z"), "")
+        self.assertEqual(config.GetSectionValue("Merged", "z"), None)
+        self.assertEqual(config.GetSectionValue("Merged", "z", BlankIsNone=False), "")
         self.assertEqual(config.GetSectionValue("Merged", "Test"), "black xxx")
         self.assertEqual(config.GetSectionValue("Merged", "More"), "ha")
         self.assertEqual(section.FormatString("[=Test]"), "black xxx")
@@ -32,7 +33,8 @@ class TestMerge(_test_case.uTestCase):
         self.assertEqual(section.GetName(), "Merged2")
         self.assertEqual(config.GetSectionValue("Merged2", "x"), "one")
         self.assertEqual(config.GetSectionValue("Merged2", "y"), "two")
-        self.assertEqual(config.GetSectionValue("Merged2", "z"), "")
+        self.assertEqual(config.GetSectionValue("Merged2", "z"), None)
+        self.assertEqual(config.GetSectionValue("Merged2", "z", BlankIsNone=False), "")
         self.assertEqual(config.GetSectionValue("Merged2", "Test"), "one")
         self.assertEqual(config.GetSectionValue("Merged2", "More"), "[=ho]")
         self.assertFailureCodes(config, ["[E11]"])
@@ -43,7 +45,8 @@ class TestMerge(_test_case.uTestCase):
         self.assertEqual(section.GetName(), "Merged3")
         self.assertEqual(config.GetSectionValue("Merged3", "x"), "one")
         self.assertEqual(config.GetSectionValue("Merged3", "y"), "two")
-        self.assertEqual(config.GetSectionValue("Merged3", "z"), "")
+        self.assertEqual(config.GetSectionValue("Merged3", "z"), None)
+        self.assertEqual(config.GetSectionValue("Merged2", "z", BlankIsNone=False), "")
         self.assertEqual(config.GetSectionValue("Merged3", "Test"), "one")
         self.assertEqual(config.GetSectionValue("Merged3", "More"), "[=ho]")
         self.assertFailureCodes(config, ["[E11]"])
@@ -57,9 +60,11 @@ class TestMerge(_test_case.uTestCase):
         self.assertFailureCodes(config, ["[E11]"])
         self.assertEqual(config.GetSectionValue("Third", "PropTest"), "[=NewProp]")
         self.assertFailureCodes(config, ["[E11]"])
+
         section = config.GetSection("Third")
         section.SetProperty("NewProp", "Silver")
         self.assertEqual(config.GetSectionValue("Third", "PropTest"), "Silver")
+
         merged1 = config.GetSection("Merged")
         section.SetLink("Other", merged1)
         self.assertEqual(config.GetSectionValue("Third", "LinkTest"), "black xxx")
@@ -67,7 +72,8 @@ class TestMerge(_test_case.uTestCase):
         self.assertEqual(dprop['PropTest'], "Silver")
         self.assertEqual(dprop['NewProp'], "Silver")
         self.assertTrue(isinstance(dprop['Other'], uConfigSection))
-        self.assertEqual(dprop['Other'].GetValue("z"), "")
+        self.assertEqual(dprop['Other'].GetValue("z"), None)
+        self.assertEqual(dprop['Other'].GetValue("z", BlankIsNone=False), '')
 
         # test expansion order
         snames = [section.GetName() for section in config.sections][1:6]


### PR DESCRIPTION
By default, blank values are returned as None.  Setting **BlankIsNone** to *False* will change this behavior to return an empty string when an empty string is specified.

For example:
```
[MySection]
# a blank value
MyValue=
```

```python
# returns None
GetValue("MyValue")
# returns ""
GetValue("MyValue", BlankIsNone=False)
# returns "red
GetValue("MyValue", Default="red")
# returns ""
GetValue("MyValue", Default="red", BlankIsNone=False)
```