### PR TITLE
bug fix: GetList separator

### DIFF
--- a/m9ini/u_config_section.py
+++ b/m9ini/u_config_section.py
@@ -520,7 +520,7 @@ class uConfigSection (ucDictionary):
         return ucType.ConvertToFloat(self.GetValue(Name, Default))
 
     def GetList(self, Name, Separator=',')->list:
-        return ucType.ConvertToList(self.GetValue(Name))
+        return ucType.ConvertToList(self.GetValue(Name), Separator)
     
     # modify native properties
 


### PR DESCRIPTION
Delimiter was not being passed down from GetList().  Separator was ',' regardless of specification.  This has been corrected.